### PR TITLE
Fail assertion instead of exiting on implementation missing

### DIFF
--- a/src/java/lang/util.d
+++ b/src/java/lang/util.d
@@ -115,7 +115,7 @@ IDwtLogger getDwtLogger(){
 void implMissing( String file, uint line ){
     getDwtLogger().fatal( file, line, "implementation missing in file {} line {}", file, line );
     getDwtLogger().fatal( file, line, "Please create a bug report at http://www.dsource.org/projects/dwt" );
-    assert(false, "Implementation missing");
+    throw new core.exception.AssertError("Implementation missing", file, line);
 }
 
 void implMissingInTango(T = void)( String file, uint line ) {


### PR DESCRIPTION
Calling exit bogs down the whole test run in a test scenario, so that other failures are swallowed.
