### PR TITLE
Hack to make getImportData work from outside util

### DIFF
--- a/src/java/lang/util.d
+++ b/src/java/lang/util.d
@@ -582,8 +582,8 @@ struct ImportData{
     TryImmutable!(void)[] data;
     String name;
 
-    //T=bool is just a hack to force opCall to be included in full in the .di file
-    public static ImportData opCall(T=bool)( TryImmutable!(void)[] data, String name ){
+    //empty () is just a hack to force opCall to be included in full in the .di file
+    public static ImportData opCall()( TryImmutable!(void)[] data, String name ){
         ImportData res;
         res.data = data;
         res.name = name;


### PR DESCRIPTION
If the ImportData opCall is not in the .di file in full, GetImportData cannot be used from outside util as the compiler cannot find the source at compile time.

This isn't an ideal solution at all, but it appears to work.
