### PR TITLE
Update for dmd 2.066 rc2.

### DIFF
--- a/src/java/nonstandard/RuntimeTraits.d
+++ b/src/java/nonstandard/RuntimeTraits.d
@@ -284,7 +284,7 @@ version(Tango){
         return null;
     }
 } else { // Phobos
-    Immutable!(ModuleInfo)* moduleOf (in ClassInfo type)
+    ModuleInfo* moduleOf (in ClassInfo type)
     {
         foreach (modula; ModuleInfo)
             foreach (klass; modula.localClasses)


### PR DESCRIPTION
Patch for dmd 2.066 rc2.

The `ModuleInfo` has returned to not immutable, So I was reverted the `RuntimeTraits#moduleOf()`.
