### PR TITLE
Fixes for dmd 2.072.

### DIFF
--- a/src/java/lang/util.d
+++ b/src/java/lang/util.d
@@ -183,7 +183,7 @@ version(Tango){
                                     fres = null;
                             } else
                                 fres ~= 's';
-                        } catch {
+                        } catch (Exception) {
                             fres = "{malformed format}";
                         }
                         if(fres)
@@ -384,15 +384,6 @@ version(Tango){
         assert( Formatter( "{}", f ) == "{1.00 => one, 3.14 => PI}" ||
                 Formatter( "{}", f ) == "{3.14 => PI, 1.00 => one}");*/
     }
-
-	private String doVarArgFormat(TypeInfo[] _arguments, core.vararg.va_list _argptr) {
-		char[] res;
-        void putc(dchar c) {
-            std.utf.encode(res, c);
-        }
-        std.format.doFormat(&putc, _arguments, _argptr);
-		return std.exception.assumeUnique(res);
-	}
 
     class Format{
         template UnTypedef(T) {

--- a/src/java/util/Timer.d
+++ b/src/java/util/Timer.d
@@ -23,7 +23,7 @@ class Timer {
 
         private static const int DEFAULT_SIZE = 32;
         private bool nullOnEmpty;
-        private TimerTask heap[];
+        private TimerTask[] heap;
         private int elements;
         public this() {
             version(Tango){
@@ -40,7 +40,7 @@ class Timer {
         private void add(TimerTask task) {
             elements++;
             if (elements is heap.length) {
-                TimerTask new_heap[] = new TimerTask[heap.length * 2];
+                TimerTask[] new_heap = new TimerTask[heap.length * 2];
                 System.arraycopy(heap, 0, new_heap, 0, cast(int)heap.length);
                 heap = new_heap;
             }
@@ -52,7 +52,7 @@ class Timer {
             heap[elements] = null;
             elements--;
             if (elements + DEFAULT_SIZE / 2 <= (heap.length / 4)) {
-                TimerTask new_heap[] = new TimerTask[heap.length / 2];
+                TimerTask[] new_heap = new TimerTask[heap.length / 2];
                 System.arraycopy(heap, 0, new_heap, 0, elements + 1);
                 heap = new_heap;
             }


### PR DESCRIPTION
Fixes for dmd 2.072.0.

doVarArgFormat is not used now, Moreover std.format.doFormat has been deprecated. So, I had to remove it.