### PR TITLE
Prep-for-DMD-v2.074.0

### DIFF
--- a/src/java/util/Locale.d
+++ b/src/java/util/Locale.d
@@ -15,7 +15,7 @@ class Locale : Cloneable {
     static Locale ITALIAN;
     static Locale ITALY;
     static Locale JAPAN;
-    static Locale JAPANESE;;
+    static Locale JAPANESE;
     static Locale KOREA;
     static Locale KOREAN;
     static Locale PRC;


### PR DESCRIPTION
These are minor edits
Replace ";;" with ";"
This is necessary to prepare for DMD v2.074.0
DMD v2.074.0 writes bad *.di files
DWT will build, but fails with warnings
The warning are fixed with my edits
Until DMD is fixed
A workaround is to import *.d files instead
This is the first step to get there